### PR TITLE
document the two roles

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -1,0 +1,16 @@
+# Roles
+There are two roles for Guardian staff conducting a coding exercise interview. The calendar invite sent by HR will include who is performing each role.
+
+## Chaperone
+Responsible for collecting the candidate from reception and bringing them to the interviewer's desk.
+
+After 45 minutes, the chaperone should briefly visit the interviewer's desk to aid as a time check.
+
+After the hour is complete, the chaperone should collect the candidate and take them back to reception.
+
+## Interviewer
+Responsible for explaining and conducting the coding exercise stage of the interview process.
+
+After the 45 minute time check, it is usually a good idea to begin to wrap up. This could include pseudo-coding any remaining tasks, refactoring discussions or answering any questions the candidate may have about the process or role.
+
+Once the hour is complete and the chaperone has collected the candidate, the interviewer should write up notes based on the [assessment criteria](https://docs.google.com/spreadsheets/d/1Pyr6pDMvisGAYPCOAAS1YDIrA_GXvCE4YUc3c-vk0H4/edit#gid=0) and make a recommendation to HR on next steps.


### PR DESCRIPTION
Providing documentation about the responsibilities of the chaperone and the interviewer at the Guardian.