### PR TITLE
migrate candidate informtion Google Doc to markdown

### DIFF
--- a/CANDIDATE_INFORMATION.md
+++ b/CANDIDATE_INFORMATION.md
@@ -1,0 +1,37 @@
+_intended audience: candidate_
+
+# Candidate Information
+
+Thank you for applying to the Guardian.
+
+Please take some time to go over the [README](./README.md) prior to your interview.
+It provides in depth information about this stage: why we perform it, what we’re trying to assess and how.
+
+As an overview, you’ll spend 60 minutes with a software engineer, 
+working through **one** of the exercises in this repository. 
+You will be writing a program that can be run from the command line.
+
+Your interviewer will tell you which exercise you’ll be working on at the start of the interview.
+
+## Remote Interviews
+We conduct remote interviews over [Google Meet](https://meet.google.com/).
+Google Meet is a video conferencing tool that supports screen sharing.
+A link will be included on your interview invitation, click it to join.
+Once joined, your interviewer will ask you to share your screen.
+
+Please note, enabling your camera is optional.
+
+### Before the interview
+We recommend your coding environment be setup **before** the interview starts.
+This is to allow you as much time as possible to demonstrate your skills as we do not assess your IDE setup.
+
+We provide [skeleton projects](https://github.com/guardian/coding-exercise-project) in a few programming languages,
+or you can set up an empty project from scratch.
+
+### After the interview
+At the end of your interview, you’ll be asked to share your solution with your interviewer for later reference,
+ideally as a [GitHub Gist](https://gist.github.com/).
+
+This will not be shared outside of the hiring group. 
+
+Thank you and good luck!

--- a/PROCESS_IN_PERSON.md
+++ b/PROCESS_IN_PERSON.md
@@ -1,3 +1,5 @@
+_intended audience: interviewer_
+
 # How to conduct an in-person interview
 
 > Guidance differs slighly for [remote interviews](/PROCESS_REMOTE.md)

--- a/PROCESS_REMOTE.md
+++ b/PROCESS_REMOTE.md
@@ -1,3 +1,5 @@
+_intended audience: interviewer_
+
 # How to conduct a remote interview
 
 > Guidance differs slighly for [in-person interviews](/PROCESS_IN_PERSON.md)

--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ We use the exercises in this repository and they are used for every Engineering 
 
 We also have [this repository](https://github.com/guardian/pairing-test-project) on GitHub with skeleton projects that can be used.
 
-## Process
+## More information
+More information for candidates can be found [here](./CANDIDATE_INFORMATION.md).
 
-Interviewers should review the [in-person](/PROCESS_IN_PERSON.md) or [remote](/PROCESS_REMOTE.md) process as applicable.
+More information for interviewers can be found:
+- [here](./PROCESS_IN_PERSON.md) for in person interviews
+- [here](./PROCESS_REMOTE.md) for remote interviews
 
 ## License
 


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

We recently adjusted our sharing policy on our internal shared drives, this has resulted in the candidate information doc being inaccessible to candidates. Oops!

This PR moves the doc into the repository. Some of the wording has also been updated, to hopefully improve clarity.

Easiest to view [here](https://github.com/guardian/coding-exercises/blob/aa-candidate-info/CANDIDATE_INFORMATION.md).

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

n/a

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

Candidates have one place to go to find information about the coding exercise stage of our hiring process.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

n/a

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
n/a