### PR TITLE
Update UKIP -> Reform UK in election night test

### DIFF
--- a/election-results/README.md
+++ b/election-results/README.md
@@ -13,8 +13,8 @@ A result will consist of:
 
 So for example:
 
-    "Cardiff West, 11014, C, 17803, L, 4923, UKIP, 2069, LD",
-    "Islington South & Finsbury, 22547, L, 9389, C, 4829, LD, 3375, UKIP, 3371, G, 309, Ind"
+    "Cardiff West, 11014, C, 17803, L, 4923, RUK, 2069, LD",
+    "Islington South & Finsbury, 22547, L, 9389, C, 4829, LD, 3375, RUK, 3371, G, 309, Ind"
 
 
 ## Tasks:
@@ -30,7 +30,7 @@ e) shows the share of the vote as a percentage of all the votes cast
 
 * C - Conservative Party
 * L - Labour Party
-* UKIP - UKIP
+* RUK - Reform UK
 * LD - Liberal Democrats
 * G - Green Party
 * Ind - Independent


### PR DESCRIPTION
## What does this change?

It ain't 2016 anymore. UKIP has been defacto rebranded as Reform UK, so let's update the election night readme to reflect this.